### PR TITLE
Fixed memory leak caused by strong reference cycle

### DIFF
--- a/DrawCircleAnimation/KNCirclePercentView/KNPercentLabel.h
+++ b/DrawCircleAnimation/KNCirclePercentView/KNPercentLabel.h
@@ -22,7 +22,7 @@
 
 @interface KNPercentLayer : CALayer
 
-@property (strong, nonatomic) id<KNPercentDelegate> tweenDelegate;
+@property (weak, nonatomic) id<KNPercentDelegate> tweenDelegate;
 @property (nonatomic) CGFloat fromValue;
 @property (nonatomic) CGFloat toValue;
 @property (nonatomic) NSTimeInterval tweenDuration;


### PR DESCRIPTION
Hey,
this fixes a memory leak caused by a strong reference cycle between tweenDelegate and layer. Please look at the screenshot from the Xcode 8 memory debugger.
Thanks,
Darko

![screen shot memory debugger](https://cloud.githubusercontent.com/assets/11902775/22308988/9c504536-e349-11e6-9f24-1e83c2d1fa23.png)
